### PR TITLE
Undeclared Identifier CGFloat

### DIFF
--- a/SOMotionDetector/SOStepDetector.m
+++ b/SOMotionDetector/SOStepDetector.m
@@ -7,6 +7,7 @@
 //  Copyright (c) 2015 Artur Mkrtchyan. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
 #import "SOStepDetector.h"
 #import <CoreMotion/CoreMotion.h>
 


### PR DESCRIPTION
While using this class, Xcode complained that CGFloat was undeclared so a simple UIKit framework import fixed it